### PR TITLE
[User service] Update refresh token

### DIFF
--- a/user-service/model/refreshToken-model.js
+++ b/user-service/model/refreshToken-model.js
@@ -4,6 +4,7 @@ const Schema = mongoose.Schema
 let RefreshTokenSchema = new Schema({
     token: {
         type: String,
+        unique: true,
         required: true,
     },
     user: {
@@ -14,7 +15,11 @@ let RefreshTokenSchema = new Schema({
         type: String,
         unique: false
     },
-    expiryDate: Date,
+    expiryDate: {
+        type: Date,
+    },
 });
+
+RefreshTokenSchema.index({ expiryDate: 1 }, { expireAfterSeconds: 1 });
 
 export default mongoose.model('RefreshTokenModel', RefreshTokenSchema)

--- a/user-service/model/refreshToken-repository.js
+++ b/user-service/model/refreshToken-repository.js
@@ -15,9 +15,9 @@ export async function createToken(params) {
     return new RefreshTokenModel(params)
 }
 
-export async function getAllToken() {
+export async function getToken(hash) {
     try {
-        const doc = await RefreshTokenModel.find({});
+        const doc = await RefreshTokenModel.findOne({token: hash});
         return doc;
     } catch (err) {
         console.log(`ERROR: RefreshTokenModel database ${err}`);

--- a/user-service/package-lock.json
+++ b/user-service/package-lock.json
@@ -16,6 +16,7 @@
         "cookie-session": "^2.0.0",
         "cors": "^2.8.5",
         "crypto": "^1.0.1",
+        "crypto-hash": "^2.0.1",
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
         "handlebars": "^4.7.7",
@@ -987,6 +988,17 @@
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
       "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
+    },
+    "node_modules/crypto-hash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-2.0.1.tgz",
+      "integrity": "sha512-t4mkp7Vh6MuCZRBf0XLzBOfhkH3nW6YEAotMDSjshVQ1GffCMGdPLSr7pKH0rdXY02jTjAZ7QW2apD0buaZXcQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/debug": {
       "version": "3.2.7",
@@ -4395,6 +4407,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
       "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
+    },
+    "crypto-hash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-2.0.1.tgz",
+      "integrity": "sha512-t4mkp7Vh6MuCZRBf0XLzBOfhkH3nW6YEAotMDSjshVQ1GffCMGdPLSr7pKH0rdXY02jTjAZ7QW2apD0buaZXcQ=="
     },
     "debug": {
       "version": "3.2.7",

--- a/user-service/package.json
+++ b/user-service/package.json
@@ -23,6 +23,7 @@
     "cookie-session": "^2.0.0",
     "cors": "^2.8.5",
     "crypto": "^1.0.1",
+    "crypto-hash": "^2.0.1",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "handlebars": "^4.7.7",


### PR DESCRIPTION
Fixes #118, Fixes #119

Issue #118: 
Add TTL for refresh token in MongoDB, which deletes the data if the refresh token is expired.

Issue #119 : 
Previously refresh token were hashed and salted, which is non-deterministic, resulting in slow get queries as all entires have to be compared individually using bycrypt.compare().

Now, since refresh token is a UUID, it is random and with SHA512 hashing, would be extremely secure as well. SHA512 hashing is deterministic and would allow us to find the refreshToken immediately using the hashed value.